### PR TITLE
Feature/truncate sketches on main view

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -1,11 +1,81 @@
 const functions = require("firebase-functions");
 
-exports.helloEgghead = functions.https.onRequest((request, response) => {
-  response.send("Hello from egghead.space!");
-});
+const marked = require("marked");
 
-exports.createSketch = functions.firestore
+// Finds all images from a markdown text
+function findImages(markdown) {
+  const renderer = new marked.Renderer();
+  const images = [];
+  renderer.image = function(href, title, text) {
+    images.push({
+      href: href,
+      title: title,
+      text: text
+    });
+    return marked.Renderer.prototype.image.apply(this, arguments);
+  };
+  marked(markdown, { renderer: renderer });
+  return images;
+}
+
+function selectImage(body) {
+  const images = findImages(body);
+  const userMarkedImages = images.filter(image => {
+    return image.href.endsWith("preview_image");
+  });
+  if (userMarkedImages.length > 0) {
+    const userMarkedImage = userMarkedImages[0];
+    console.log(`Found user marked image: ${JSON.stringify(userMarkedImage)}`);
+    console.log("... and using this image for preview.");
+    return userMarkedImage.href;
+  }
+  console.log("No user marked image. Selecting best image :D");
+  console.log("No yet...");
+  return null;
+}
+
+exports.onSketchCreated = functions.firestore
   .document("sketches/{sketchId}")
   .onCreate((snap, context) => {
-    console.log("new sketch: '%s'", snap.data().title);
+    console.log("Sketch created. Id: '%s'", snap.id);
+    const data = snap.data();
+    const body = data.body;
+    const imageLink = selectImage(body);
+    if (imageLink !== null && imageLink !== data.previewImage) {
+      console.log("Image has changed. Setting new property");
+      return snap.ref.set(
+        {
+          previewImage: imageLink
+        },
+        {
+          merge: true
+        }
+      );
+    }
+    return null;
+  });
+
+exports.onSketchModified = functions.firestore
+  .document("sketches/{sketchId}")
+  .onUpdate((change, context) => {
+    console.log("Sketch modified. Id: '%s'", change.after.id);
+    const data = change.after.data();
+    const body = data.body;
+    const previousData = change.before.data();
+    if (body === previousData.body) {
+      console.log("Body didn't change, nothing to do.");
+    }
+    const imageLink = selectImage(body);
+    if (imageLink !== null && imageLink !== data.previewImage) {
+      console.log("Image has changed. Setting new property");
+      return change.after.ref.set(
+        {
+          previewImage: userMarkedImage.href
+        },
+        {
+          merge: true
+        }
+      );
+    }
+    return null;
   });

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -3455,6 +3455,11 @@
         "object-visit": "1.0.1"
       }
     },
+    "marked": {
+      "version": "0.3.19",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
+      "integrity": "sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg=="
+    },
     "media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",

--- a/functions/package.json
+++ b/functions/package.json
@@ -11,7 +11,8 @@
   },
   "dependencies": {
     "firebase-admin": "~5.12.0",
-    "firebase-functions": "^1.0.1"
+    "firebase-functions": "^1.0.1",
+    "marked": "^0.3.19"
   },
   "devDependencies": {
     "eslint": "^4.12.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14372,6 +14372,11 @@
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
       "dev": true
     },
+    "striptags": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/striptags/-/striptags-3.1.1.tgz",
+      "integrity": "sha1-yMPn/db7S7OjKjt1LltePjgJPr0="
+    },
     "supports-color": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13763,6 +13763,11 @@
         }
       }
     },
+    "shave": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/shave/-/shave-2.1.3.tgz",
+      "integrity": "sha512-rMPGBWone5TmnkK84ZhMZMLStiQP/etig1Dofyv7VNxsl1WmIlU2/e9BgUj9l/H8z1RqulOf32gbSUeAEIUPfA=="
+    },
     "shebang-command": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "markdown-it": "^8.4.1",
     "roboto-fontface": "^0.9.0",
     "simplemde": "https://github.com/Ionaru/simplemde-markdown-editor/archive/c30569edb36b1a6eb60e2007be9900107cc9d3c9.tar.gz",
+    "striptags": "^3.1.1",
     "vue": "^2.5.13",
     "vue-router": "^3.0.1",
     "vuefire": "^2.0.0-alpha.9",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "firebaseui": "^2.7.0",
     "markdown-it": "^8.4.1",
     "roboto-fontface": "^0.9.0",
+    "shave": "^2.1.3",
     "simplemde": "https://github.com/Ionaru/simplemde-markdown-editor/archive/c30569edb36b1a6eb60e2007be9900107cc9d3c9.tar.gz",
     "striptags": "^3.1.1",
     "vue": "^2.5.13",

--- a/src/components/SketchSummary.vue
+++ b/src/components/SketchSummary.vue
@@ -7,7 +7,7 @@
     <v-card-actions>
       <span class="author-link">by <router-link :to="{name: 'user', params: {uid: this.sketch.createdByUid}}">{{author}}</router-link></span>
       <v-spacer></v-spacer>
-      <v-btn v-if="showDetailsLink" :to="{name: 'sketch', params: {id: this.sketch.id, title: this.sketch.title.replace(/\s/g, '+')}}" flat>
+      <v-btn v-if="showDetailsLink" :to="{name: 'sketch', params: {id: this.sketch.id, title: this.sketch.title.replace(/\s/g, '+')}}" flat small color="primary">
         Show more
       </v-btn>
     </v-card-actions>
@@ -82,8 +82,8 @@ export default {
   }
   .author-link {
     position: relative;
-    top: 15px;
-    left: -5px;
+    top: 12px;
+    left: -4px;
     a {
       text-decoration: none;
     }

--- a/src/components/SketchSummary.vue
+++ b/src/components/SketchSummary.vue
@@ -1,0 +1,95 @@
+<template>
+  <v-card class="sketch">
+    <v-card-title primary-title>
+      <h3 class="headline text-title" v-html="title"></h3>
+    </v-card-title>
+    <v-card-text v-html="truncatedBody" class="text-preview fade-out"></v-card-text>
+    <v-card-actions>
+      <span class="author-link">by <router-link :to="{name: 'user', params: {uid: this.sketch.createdByUid}}">{{author}}</router-link></span>
+      <v-spacer></v-spacer>
+      <v-btn v-if="showDetailsLink" :to="{name: 'sketch', params: {id: this.sketch.id, title: this.sketch.title.replace(/\s/g, '+')}}" flat>
+        Show more
+      </v-btn>
+    </v-card-actions>
+  </v-card>
+</template>
+
+<script>
+import striptags from "striptags";
+
+export default {
+  props: {
+    sketch: {
+      default: () => {
+        return {};
+      },
+      type: Object
+    },
+    showDetailsLink: {
+      default: true,
+      type: Boolean
+    }
+  },
+  computed: {
+    title() {
+      const maxLength = 28;
+      return this.sketch.title.length <= maxLength
+        ? this.sketch.title
+        : this.sketch.title.substr(0, maxLength) + "&hellip;";
+    },
+    truncatedBody() {
+      const html = this.marked(this.sketch.body);
+      const truncatedBody = striptags(html, ["p"])
+        .replace(/<p>/g, "")
+        .replace(/<\/p>/g, "");
+      console.log(`truncated: ${truncatedBody}`);
+      return truncatedBody;
+    },
+    author() {
+      return this.sketch.createdBy.displayName;
+    }
+  }
+};
+</script>
+
+<style lang="scss">
+.sketch {
+  .text-title {
+    overflow: hidden;
+  }
+  .text-preview {
+    height: 100px;
+    overflow: hidden;
+  }
+  .fade-out {
+    position: relative;
+    max-height: 350px; // change the height
+  }
+  .fade-out:after {
+    /* prettier-ignore */
+    content: '';
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    /* prettier-ignore */
+    background-image: linear-gradient( rgba(255, 255, 255, 0) 50%, rgba(255, 255, 255, 1) 100% );
+  }
+  .author-link {
+    position: relative;
+    top: 15px;
+    left: -5px;
+    a {
+      text-decoration: none;
+    }
+    a:hover {
+      text-decoration: underline;
+    }
+  }
+  .author-link,
+  .author-link a {
+    color: #666;
+  }
+}
+</style>

--- a/src/components/SketchSummary.vue
+++ b/src/components/SketchSummary.vue
@@ -1,5 +1,6 @@
 <template>
   <v-card class="sketch">
+    <v-card-media v-if="this.sketch.previewImage" :src="this.sketch.previewImage" height="200px"></v-card-media>
     <v-card-title primary-title>
       <h3 class="headline text-title" v-html="title"></h3>
     </v-card-title>

--- a/src/views/Create.vue
+++ b/src/views/Create.vue
@@ -1,11 +1,49 @@
 <template>
   <v-container grid-list-md fluid fill-height>
+    <v-dialog v-model="showHelp" max-width="580px">
+      <v-card>
+        <v-card-title>
+          <h3 class="headline mb-0">Help</h3>
+        </v-card-title>
+        <v-card-text class="help">
+          <p>You can control which image we choose for your sketches preview:
+            <ol>
+              <li>Make the URL end with "preview_image":<br>
+                Example: <code>![Alt txt](https://xmpl.url/image.jpeg#<u>preview_image</u> "title txt")</code>
+              </li>
+              <li>Include "preview image" in the alt text:.<br>
+                Example: <code>![Alt txt. Used for <u>preview image</u>](https://xmpl.url/image.jpeg "title txt")</code>
+              </li>
+              <li>Include "preview image" int the title text:<br>
+                Example: <code>![Alt txt](https://xmpl.url/image.jpeg "Title txt. Used for <u>preview image</u>"")</code>
+              </li>
+              <li>If you don't give us any hints, we will just use the first image and call it a day.
+              </li>
+            </ol>
+          </p>
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer></v-spacer>
+          <v-btn color="primary" flat @click.stop="showHelp=false">Got it</v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
     <v-layout row wrap>
       <v-flex id="input-container">
         <v-card >
           <v-card-title>
             <h3 class="headline mb-0">Create new sketch</h3>
+            <v-spacer></v-spacer>
+            <v-btn @click="showHelp = true" flat icon>
+              <v-icon>help_outline</v-icon>
+            </v-btn>
           </v-card-title>
+          <div id="protip">
+            Protip:
+            <p>If you include images in your sketch (which you totally should btw),
+            we will include one of them in your sketches preview. Click Help to see how.
+            </p>
+          </div>
           <v-card-text>
             <v-text-field v-model="title" required label="Add a good title"></v-text-field>
             <div id="editor">
@@ -51,7 +89,7 @@ export default {
       sketches: [],
       title: "",
       body: "",
-      dialog: false,
+      showHelp: false,
       next: null
     };
   },
@@ -124,6 +162,16 @@ export default {
 }
 .CodeMirror,
 .CodeMirror-scroll {
-  max-height: 500px;
+  max-height: 50px;
+}
+#protip {
+  margin-left: 50px;
+  margin-right: 30px;
+}
+.help ol {
+  margin: 10px 10px 15px 30px;
+  li + li {
+    margin-top: 7px;
+  }
 }
 </style>

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -1,8 +1,10 @@
 <template>
-  <v-container>
+  <v-container fluid grid-list-lg>
     <v-layout row wrap>
-      <v-flex xs12>
-        <Sketch v-for="sketch of orderedSketches" :key="sketch.id" :sketch="sketch"></Sketch>
+      <v-flex xs12 md6 lg4 v-for="sketch of orderedSketches" :key="sketch.id">
+        <v-card flat tile>
+          <SketchSummary :sketch="sketch"></SketchSummary>
+        </v-card>
       </v-flex>
     </v-layout>
     <v-btn id="create-sketch-button" to="/create" title="Create new sketch" color="primary" fab top right fixed>
@@ -12,7 +14,7 @@
 </template>
 
 <script>
-import Sketch from "@/components/Sketch.vue";
+import SketchSummary from "@/components/SketchSummary.vue";
 import "simplemde/dist/simplemde.min.css";
 import { db } from "@/firebase";
 
@@ -21,7 +23,7 @@ const orderedSketches = db.collection("sketches").orderBy("created", "desc");
 export default {
   name: "Home",
   components: {
-    Sketch
+    SketchSummary
   },
   data() {
     return {


### PR DESCRIPTION
Home view now only shows a preview for sketches:

  - All headings are removed from text and all html-tags stripped
  - Awesome text reflow via dollarshaveclub/shave
  - An image from the sketch body will be used es preview image on home view
  - New help dialog for create view

Fixes #15